### PR TITLE
Handle missing keys in handler()

### DIFF
--- a/create_order.py
+++ b/create_order.py
@@ -1,13 +1,16 @@
 def handler(body):
-    # Attempt to access 'order_items' key in the dictionary
-    order_items = body["order_items"]
-    print(order_items)
+    # Check if 'order_items' key exists before accessing
+    if 'order_items' in body:
+        order_items = body['order_items']
+        print(order_items)
+    else:
+        print('No order items found')
 
 # Sample body dictionary without 'order_items' key
 body = {
-    "customer_name": "John Doe",
-    "order_id": 123456
+    'customer_name': 'John Doe',
+    'order_id': 123456
 }
 
-# Call the function, which will raise KeyError
+# Call the function, which will no longer raise KeyError
 handler(body)


### PR DESCRIPTION
The body dictionary being passed into handler() does not contain the expected 'order_items' key. This raises a KeyError. Check if the key exists before trying to access it.