### PR TITLE
Handle missing 'payment_method' key

### DIFF
--- a/process_payment.py
+++ b/process_payment.py
@@ -1,10 +1,15 @@
 def process_payment(info):
-    payment_method = info["payment_method"]
-    print("Processing payment using:", payment_method)
+    try:
+        payment_method = info['payment_method']
+    except KeyError:
+        print('Payment method not provided')
+        return
+    
+    print('Processing payment using:', payment_method)
 
 info = {
-    "customer_name": "Alice Smith",
-    "total_amount": 200
+    'customer_name': 'Alice Smith',
+    'total_amount': 200
 }
 
 process_payment(info)


### PR DESCRIPTION
The info dictionary passed to process_payment does not contain a 'payment_method' key. Added a check for KeyError when accessing the 'payment_method' key and returning early if it doesn't exist.