### PR TITLE
Handle missing key in get_user_email

### DIFF
--- a/get_user_email.py
+++ b/get_user_email.py
@@ -1,11 +1,6 @@
 def get_user_email(user_info):
-    email = user_info["email"]
-    print("User email:", email)
-
-user_info = {
-    "user_name": "Bob Johnson",
-    "user_id": 101
-}
-
-if __name__ == "__main__":
-    get_user_email(user_info)
+    if 'email' in user_info:
+        email = user_info['email']
+    else:
+        email = None
+    return email


### PR DESCRIPTION
The KeyError occurs because the 'email' key does not exist in the user_info dictionary. To fix this, check if the key exists before trying to access it.