### PR TITLE
Handle missing 'model_year' key

### DIFF
--- a/script.py
+++ b/script.py
@@ -1,11 +1,14 @@
 def get_vehicle_detail(vehicle_data):
-    model_year = vehicle_data["model_year"]
-    print("Vehicle model year:", model_year)
+    try:
+        model_year = vehicle_data['model_year']
+    except KeyError:
+        model_year = None
+    print('Vehicle model year:', model_year)
 
 vehicle_data = {
-    "make": "Toyota",
-    "model": "Camry"
+    'make': 'Toyota',
+    'model': 'Camry'
 }
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     get_vehicle_detail(vehicle_data)


### PR DESCRIPTION
The vehicle_data dictionary does not contain a 'model_year' key. Added a check for KeyError when accessing the 'model_year' key and returning None if it does not exist.