### PR TITLE
Handle missing address key

### DIFF
--- a/print_customer_address.py
+++ b/print_customer_address.py
@@ -1,11 +1,14 @@
 def print_customer_address(order_record):
-    address = order_record["address"]
-    print("Customer address:", address)
+    if 'address' in order_record:
+        address = order_record['address']
+        print('Customer address:', address)
+    else:
+        print('Address not provided')
 
 order_record = {
-    "customer_name": "Samantha Green",
-    "order_id": 7890
+    'customer_name': 'Samantha Green',
+    'order_id': 7890
 }
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     print_customer_address(order_record)


### PR DESCRIPTION
The order_record dict does not contain an 'address' key. Check if the key exists before trying to access it.