### PR TITLE
Handle missing keys in get_age()

### DIFF
--- a/get_age.py
+++ b/get_age.py
@@ -1,13 +1,16 @@
 def get_age(data):
-    # Attempt to access 'age' key in the dictionary
-    age = data["age"]
-    print("Age:", age)
+    # Check if 'age' key exists before accessing
+    if 'age' in data:
+        age = data['age']
+        print('Age:', age)
+    else:
+        print('Age not provided')
 
 # Sample data dictionary without 'age' key
 data = {
-    "name": "Eric Johnson",
-    "occupation": "Engineer"
+    'name': 'Eric Johnson',
+    'occupation': 'Engineer'
 }
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     get_age(data)


### PR DESCRIPTION
The KeyError occurs because the 'data' dictionary passed to get_age() does not contain the expected 'age' key. To handle this, I've modified get_age() to check if 'age' exists in the data before trying to access it.