### PR TITLE
Handle missing 'city' key

### DIFF
--- a/show_city.py
+++ b/show_city.py
@@ -1,11 +1,15 @@
 def show_city(info):
-    city = info["city"]
-    print("City:", city)
+    try:
+        city = info['city']
+    except KeyError:
+        print('City: Unknown')
+        return
+    print('City:', city)
 
 info = {
-    "name": "Jessica Lee",
-    "country": "Canada"
+    'name': 'Jessica Lee',
+    'country': 'Canada'
 }
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     show_city(info)


### PR DESCRIPTION
The info dictionary does not contain a 'city' key. Added a check for KeyError when accessing the 'city' key and print a default message if it does not exist.