### PR TITLE
Handle missing keys in employee_data

### DIFF
--- a/get_salary.py
+++ b/get_salary.py
@@ -1,11 +1,14 @@
 def get_salary(employee_data):
-    salary = employee_data["salary"]
-    print("Salary:", salary)
+    if 'salary' in employee_data:
+        salary = employee_data['salary']
+        print('Salary:', salary)
+    else:
+        print('Salary not found')
 
-employee_data = {
-    "name": "Mark Thompson",
-    "position": "Software Developer"
-}
-
-if __name__ == "__main__":
+if __name__ == '__main__':
+    employee_data = {
+        'name': 'Mark Thompson',
+        'position': 'Software Developer'
+    }
+    
     get_salary(employee_data)


### PR DESCRIPTION
The employee_data dictionary does not contain a 'salary' key. Check if the key exists before trying to access it.